### PR TITLE
Disable confirmation emails

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,8 +7,10 @@ This deployment now includes AWS SES (Simple Email Service) integration for the 
 ### Quick Deployment
 
 ```bash
-# Deploy with email parameter
-./deploy.sh --email your-email@domain.com
+# Deploy with email parameters
+#   --email is the verified sender (domain email)
+#   --recipient-email is where submissions are delivered
+./deploy.sh --email sender@your-domain.com --recipient-email barrierstojustice.mit@gmail.com
 
 # Or using short flag
 ./deploy.sh -e your-email@domain.com


### PR DESCRIPTION
## Summary
- disable automatic confirmation emails to submitters by commenting out the call in `send_contact_email`
- update deployment docs to remove mention of confirmation emails

## Testing
- `python -m py_compile api/email_service.py`
- `bash -n deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5073798ec8320b5e384bdfe485485